### PR TITLE
Dont send email for each publisher update

### DIFF
--- a/app/services/publisher_update.rb
+++ b/app/services/publisher_update.rb
@@ -17,6 +17,7 @@ module Citygram
             ON ST_Intersects(subscriptions.geom, events.geom)
             AND subscriptions.publisher_id = events.publisher_id
             AND subscriptions.unsubscribed_at IS NULL
+            AND channel <> 'email'
           WHERE events.id in ?
         SQL
 

--- a/spec/services/publisher_update_spec.rb
+++ b/spec/services/publisher_update_spec.rb
@@ -62,8 +62,9 @@ describe Citygram::Services::PublisherUpdate do
     clt_area = '{"type":"Polygon","coordinates":[[[-80.93490600585938,35.263561862152095],[-80.69320678710938,35.32745068492882],[-80.60531616210938,35.14124815600257],[-80.83328247070312,35.06597313798418],[-80.93490600585938,35.263561862152095]]]}'
     subscription = create(:subscription, publisher_id: publisher.id, geom: clt_area)
 
-    # ensure we don't queue jobs for dead subscriptions
+    # ensure we don't queue jobs for dead subscriptions or emails (only for digests currently)
     create(:subscription, publisher_id: publisher.id, geom: clt_area, unsubscribed_at: DateTime.now)
+    create(:subscription, channel: 'email', email_address: 'a@b.c', publisher_id: publisher.id, geom: clt_area)
 
     expect{ Citygram::Services::PublisherUpdate.call(features, publisher) }.
       to change{ Citygram::Workers::Notifier.jobs.count }.by(+3)


### PR DESCRIPTION
@invisiblefunnel I fixed ETL automation and noticed I got an email for each event in my email subscription. 

I reckon this PR will make sure emails are only sent by `rake digests:send`. Other approaches welcome.
