### PR TITLE
Adding Map to Digests

### DIFF
--- a/app/views/digest.erb
+++ b/app/views/digest.erb
@@ -16,6 +16,24 @@
       </div>
     </div>
   </div>
+  <script>
+    $(document).ready(function() {
+      var events = [];
+      <% @events.each do |event| %>
+        events.push(<%= event.to_json %>);
+      <% end %>
+      app.hookupMap();
+      events.forEach(app.displayEventMarker);
+      console.log(<%= @subscription.geom %>);
+      //Zoom to fit all markers
+      app.map.fitBounds(app.eventMarkers.getBounds());
+    });
 
+
+
+    
+  </script>
+  <div id = 'map' style = 'height: 400px; margin-top: 28px;'>
+  </div>
   <%= erb :_digest_events %>
 </div>

--- a/app/views/layouts/layout.erb
+++ b/app/views/layouts/layout.erb
@@ -18,12 +18,12 @@
 
   <!-- the freshest styles -->
   <link rel="stylesheet" type="text/css" href="<%= asset_path 'application.css' %>">
-
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 </head>
 <body>
   <%= yield %>
 
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+  
 
   <script src="//api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.js"></script>
 


### PR DESCRIPTION
Added a map to the digests page.

Uses erb to inject event objects into javascript, had to move loading of jquery to <head> so I could use .ready().  (It has occurred to me that there is an API endpoint to get events within a geom, and that is probably a better method)

Tried to use as much of scripts.js as possible since it's already loading, however now the map is initializing twice causing an error.

Is there some way to add all of this to scripts.js as a function and then only call that function when the digests page is loaded?

