### PR TITLE
Short circuit pagination if a page with no new records is returned

### DIFF
--- a/app/workers/publisher_poll.rb
+++ b/app/workers/publisher_poll.rb
@@ -21,7 +21,7 @@ module Citygram::Workers
 
       # save any new events
       feature_collection = response.body
-      Citygram::Services::PublisherUpdate.call(feature_collection.fetch('features'), publisher)
+      new_events = Citygram::Services::PublisherUpdate.call(feature_collection.fetch('features'), publisher)
 
       # OPTIONAL PAGINATION:
       #
@@ -29,7 +29,7 @@ module Citygram::Workers
       # queue up a job to retrieve the next page
       #
       next_page = response.headers[NEXT_PAGE_HEADER]
-      if valid_next_page?(next_page, url) && page_number < MAX_PAGE_NUMBER
+      if new_events.any? && valid_next_page?(next_page, url) && page_number < MAX_PAGE_NUMBER
         self.class.perform_async(publisher_id, next_page, page_number + 1)
       end
     end


### PR DESCRIPTION
Citygram will queue jobs for up to ten sequential pages if the `Next-Page` header is given. It may not always be necessary to pull all those pages. One indicator is when a page in the sequence yields no new events. In this case, bail out of the pagination chain. If this becomes limiting, let's reevaluate. For now, I'm comfortable that this is the right behavior. Please note, there is an important assumption baked into pagination: that the endpoint orders events to return the latest first.
