### PR TITLE
Hide dot legend when events are polygons

### DIFF
--- a/app/assets/js/scripts.js
+++ b/app/assets/js/scripts.js
@@ -46,7 +46,8 @@ app.hookupSteps = function() {
 
     // Update the confirmation section with the name
     app.state.publisher_id = $publisher.data('publisher-id');
-    app.eventsArePolygons = ($publisher.data('publisher-title').match(/Leaf Collection/))
+    app.eventsArePolygons = $publisher.data('publisher-title').match(/Leaf Collection/);
+    $('.js-dot-legend').css('visibility', app.eventsArePolygons ? 'hidden' : 'visible');
 
     $('.confirmationType').html($publisher.data('publisher-title'));
 

--- a/app/views/show.erb
+++ b/app/views/show.erb
@@ -79,7 +79,7 @@
   <div class="row">
     <div class="col-md-offset-1 col-md-10">
       <div id="map">
-        <div class="map-key-panel">
+        <div class="map-key-panel js-dot-legend">
           <span class="map-event-dot"></span>Click to see notification
         </div>
       </div>


### PR DESCRIPTION
The event dot legend obscures the event pop-up on mobile so this hides it.
