### PR TITLE
Add digest url to sms welcome

### DIFF
--- a/app/workers/subscription_confirmation.rb
+++ b/app/workers/subscription_confirmation.rb
@@ -3,6 +3,10 @@ module Citygram::Workers
     include Sidekiq::Worker
     sidekiq_options retry: 5
 
+    def digest_url(subscription)
+      Citygram::Routes::Helpers.build_url(Citygram::App.application_url, "/digests/#{subscription.id}/events")
+    end
+
     def perform(subscription_id)
       subscription = Subscription.first!(id: subscription_id)
       publisher = subscription.publisher
@@ -10,7 +14,7 @@ module Citygram::Workers
       # TODO: get rid of this case statement
       case subscription.channel
       when 'sms'
-        body = "Welcome! You are now subscribed to #{publisher.title} in #{publisher.city}. Woohoo! If you'd like to give feedback, text back with your email. To unsubscribe from all messages, reply REMOVE."
+        body = "Welcome! You are now subscribed to #{publisher.title} in #{publisher.city}. Woohoo! To see current Citygrams please visit #{digest_url(subscription)}. To unsubscribe from all messages, reply REMOVE."
 
         Citygram::Services::Channels::SMS.sms(
           from: Citygram::Services::Channels::SMS::FROM_NUMBER,
@@ -18,10 +22,8 @@ module Citygram::Workers
           body: body
         )
       when 'email'
-        url = Citygram::Routes::Helpers.build_url(Citygram::App.application_url, "/digests/#{subscription.id}/events")
-
         body = <<-BODY.dedent
-          <p>Thank you for subscribing! <a href="#{url}">View Citygrams</a> in a browser.</p>
+          <p>Thank you for subscribing! <a href="#{digest_url(subscription)}">View Citygrams</a> in a browser.</p>
         BODY
 
         Citygram::Services::Channels::Email.mail(

--- a/spec/workers/subscription_confirmation_spec.rb
+++ b/spec/workers/subscription_confirmation_spec.rb
@@ -41,7 +41,7 @@ describe Citygram::Workers::SubscriptionConfirmation do
     let!(:subscription) { create(:subscription, channel: 'sms', phone_number: '212-555-1234') }
 
     before do
-      body = "Welcome! You are now subscribed to #{publisher.title} in #{publisher.city}. Woohoo! If you'd like to give feedback, text back with your email. To unsubscribe from all messages, reply REMOVE."
+      body = "Welcome! You are now subscribed to #{publisher.title} in #{publisher.city}. Woohoo! To see current Citygrams please visit #{subject.digest_url(subscription)}. To unsubscribe from all messages, reply REMOVE."
 
       stub_request(:post, "https://dev-account-sid:dev-auth-token@api.twilio.com/2010-04-01/Accounts/dev-account-sid/Messages.json").
         with(body: {


### PR DESCRIPTION
The digest url is helpful when people subscribe to a single event polygon (eg a leaf collection zone) and want to see its current status right away.

@tchu88 @invisiblefunnel pass along any thoughts.
