### PR TITLE
Generate full URL for unsubscribe link in email.

### DIFF
--- a/app/views/email.erb
+++ b/app/views/email.erb
@@ -20,7 +20,7 @@
               <% single = events.count == 1 %>
               <h5>In the last week, there <%=  single ? 'was' : 'were' %> <span class="orange"><%= events.count %> citygram<%= single ? '' : 's' %></span> for <span class="green"><%= subscription.publisher.title %></span> in the area you selected.</h5>
               <h5>Here they are below, or view them <a href="<%= Citygram::Routes::Helpers.build_url(Citygram::App.application_url, "/digests/#{subscription.id}/events") %>" class="red">in a browser</a>.</h5>
-               <a href = "/unsubscribe/<%= subscription.id %>">One-click Unsubscribe</a>
+                <a href="<%= Citygram::Routes::Helpers.build_url(Citygram::App.application_url, "/unsubscribe/#{subscription.id}") %>">One-click Unsubscribe</a>
               <br><br>
 
               <table style="width:100%; font-size:11pt" bgcolor="#F8F9F9">


### PR DESCRIPTION
This fixes a bug in the email where the unsubscribe link was relative (`/unsubscribe/abc-123`), not full (`https://www.citygram.com/unsubscribe/abc-123`). I noticed this when I tried to unsubscribe from a link in gmail.