### PR TITLE
Test console factory girl

### DIFF
--- a/lib/database_helper.rb
+++ b/lib/database_helper.rb
@@ -103,8 +103,10 @@ module Citygram
 
     def self.console(ctx = self)
       require File.expand_path('../../app', __FILE__)
-      require 'factory_girl'
-      require File.join(app_root, 'spec/factories')
+      if ENV['RACK_ENV'] == 'test'
+        require 'factory_girl'
+        require File.join(app_root, 'spec/factories')
+      end
       ctx.send :include, FactoryGirl::Syntax::Methods
       require 'irb'
       ARGV.clear

--- a/lib/database_helper.rb
+++ b/lib/database_helper.rb
@@ -106,8 +106,8 @@ module Citygram
       if ENV['RACK_ENV'] == 'test'
         require 'factory_girl'
         require File.join(app_root, 'spec/factories')
+        ctx.send :include, FactoryGirl::Syntax::Methods
       end
-      ctx.send :include, FactoryGirl::Syntax::Methods
       require 'irb'
       ARGV.clear
       IRB.start


### PR DESCRIPTION
When loading the console on Heroku the lack of FactoryGirl caused a missing library exception.

This adds an environmentally conditional require around the factorygirl library in the console rake command.

This has been merged on https://github.com/BetaNYC/citygram-nyc/pull/44 and is running at https://citygram-nyc-codeforamerica.herokuapp.com/new-york