### PR TITLE
City Title in banner

### DIFF
--- a/app/assets/css/styles.css.erb
+++ b/app/assets/css/styles.css.erb
@@ -37,6 +37,10 @@ strong {
   font-weight: 700;
 }
 
+.no-wrap {
+  white-space: nowrap;
+}
+
 /*********** Form Elements **************/
 
 .bigButton {
@@ -139,6 +143,7 @@ header h1 {
   text-shadow: 0 2px 15px rgba(0, 0, 0, 0.25);
   color: #fff;
   font-weight: 700;
+  line-height: 1em;
 }
 
 header h3 {

--- a/app/views/show.erb
+++ b/app/views/show.erb
@@ -10,10 +10,10 @@
     </a>
   </div>
   <div class="row">
-    <h1 id="title" class="col-xs-offset-1 col-md-offset-1 col-md-10">Subscribe to your city.</h1>
+    <h1 id="title" class="col-xs-offset-1 col-md-offset-1 col-md-10">Subscribe to <span class="no-wrap"><%= @city.title %></span>.</h1>
   </div>
   <div class="row">
-    <h3 class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-5">Get updates on the topics and areas you care about in <%= @city.title %>.</h3>
+    <h3 class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-5">Get updates on the topics and areas you care about in <span class="no-wrap"><%= @city.title %></span>.</h3>
     <div id="start" class="hidden-xs hidden-sm col-md-offset-3 bigButton startButton">Get started</div>
   </div>
 </header>


### PR DESCRIPTION
Over at http://citygram.nyc we use the name of the city in the tagline.

![screen shot 2015-03-15 at 4 49 15 pm](https://cloud.githubusercontent.com/assets/81055/6658049/422648ba-cb33-11e4-9c84-faf4d7a5ecba.png)

https://citygram.org/new-york does not include the city name.

![screen shot 2015-03-15 at 4 49 20 pm](https://cloud.githubusercontent.com/assets/81055/6658046/3f88bf02-cb33-11e4-8340-c0d90c3cc925.png)

This pull request implements this across all cities in the show template.

This title is the `<h1>` element of the page, I feel it is very important to have the city name in there.

To ensure the name does not wrap I added a new css helper class [`no-wrap`](https://github.com/codeforamerica/citygram/compare/master...BetaNYC:banner-city-name#diff-bdbfcaab3932a5e258ce07d8503027b7R40), I also fixed the line height to avoid inconsistencies at different screen sizes.

![screen shot 2015-03-15 at 4 55 13 pm](https://cloud.githubusercontent.com/assets/81055/6658067/22f14d5e-cb34-11e4-8316-c13fe7020b01.png)

![screen shot 2015-03-15 at 4 55 17 pm](https://cloud.githubusercontent.com/assets/81055/6658068/2581bd60-cb34-11e4-9254-6fb0d6330333.png)

---

# San Francisco was the perfect test piece

![screen shot 2015-03-15 at 4 46 01 pm](https://cloud.githubusercontent.com/assets/81055/6658040/2696a892-cb33-11e4-94c8-ec2dc148d2ce.png)
![screen shot 2015-03-15 at 4 45 56 pm](https://cloud.githubusercontent.com/assets/81055/6658041/269af74e-cb33-11e4-88c1-92cccdd2a750.png)
![screen shot 2015-03-15 at 4 45 52 pm](https://cloud.githubusercontent.com/assets/81055/6658042/269ba414-cb33-11e4-86df-02059f389bc6.png)