### PR TITLE
City in Page title, if City

### DIFF
--- a/app/views/layouts/layout.erb
+++ b/app/views/layouts/layout.erb
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="mapId" content="<%= Citygram::App.map_id %>">
-  <title>Citygram</title>
+  <title>Citygram <%= @city.title if @city %></title>
 
   <!-- typekit -->
   <script type="text/javascript" src="//use.typekit.net/olg1fvr.js"></script>


### PR DESCRIPTION
> Sorry for the InterExchange logos in these screenshots, this is fixed in #176.

![screen shot 2015-03-15 at 5 22 39 pm](https://cloud.githubusercontent.com/assets/81055/6658184/f1687ab0-cb37-11e4-84e5-fb03fd21acbd.png)

This adds the city title to pages where a city is present.

![screen shot 2015-03-15 at 5 22 50 pm](https://cloud.githubusercontent.com/assets/81055/6658185/f582ee78-cb37-11e4-95cf-4d1f05e1bcc1.png)
