### PR TITLE
Don't fix a specific ruby version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,7 @@
 source 'https://rubygems.org'
 
-if ENV['CI']
-  ruby RUBY_VERSION
-else
-  ruby '2.2.2'
-end
+raise 'Ruby should be >= 2.0' unless RUBY_VERSION.to_f >= 2.0
+ruby RUBY_VERSION
 
 gem 'activesupport', require: 'active_support'
 gem 'airbrake', require: false


### PR DESCRIPTION
**Issue:**

* When running `citygram`, I had Ruby 2.2.1 installed, and the `Gemfile` insisted I need Ruby 2.2.2.

**Solution:**

* Use the following [stack overflow answer](http://stackoverflow.com/questions/28440712/how-can-i-specify-a-minimum-ruby-version-in-a-gemfile) to require a minimum Ruby version of 2.0. <= is this the right minimum version?

**Testing:**

* I tested that this allowed me to run with Ruby 2.2.1.