### PR TITLE
Update readme for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Citygram is a web application written in Ruby.
 * Job Queue: [Redis](http://redis.io/), [Sidekiq](https://github.com/mperham/sidekiq)
 * Tests: [RSpec](https://github.com/rspec), [FactoryGirl](https://github.com/thoughtbot/factory_girl), [Rack::Test](https://github.com/brynary/rack-test)
 
-### Setup
+### Installation and configuration
 
 ### Installation
 
@@ -41,9 +41,7 @@ First, follow the instructions to install each of the following:
 * Install PostGIS -- refer to [these troubles](https://github.com/codeforamerica/citygram/issues/188) on Mac OS X
 * Install Redis - `brew install redis`
 
-#### Install Dependencies
-
-In the command line, run the following:
+Then, in the command line, run the following to copy the citygram code locally and install all Ruby package dependencies:
 
 ```
 git clone https://github.com/codeforamerica/citygram.git
@@ -55,9 +53,6 @@ rbenv rehash
 bundle install
 ```
 
-This will copy the code locally, then install all Ruby package dependencies.
-
-
 #### Configure Environment
 
 Make sure your PostgreSQL server is running, then in the terminal run:
@@ -68,7 +63,11 @@ rake db:create db:migrate
 rake db:create db:migrate DATABASE_URL=postgres://localhost/citygram_test
 ```
 
-### Developing
+### Running Citygram Website and Services
+
+Basic things you'll want to do with your Citygram server:
+
+##### Run the server
 
 To boot up the complete application and run background jobs in development:
 ```
@@ -80,24 +79,13 @@ Then, in a new terminal window, run:
 open http://localhost:5000/
 ```
 
-
-##### Single City Installation
-
-If you only need to support a single city you can specify the <kbd>ROOT_CITY_TAG</kbd> to bypass the index and load one city.
-
-For example, https://www.citygram.nyc/ is a single city installation with the following environment variable
-
-```
-ROOT_CITY_TAG=new-york
-```
-
-##### Sending a Digest
+##### Send a digest
 
 ```
 rake digests:send
 ```
 
-##### Sending a Weekly Digest
+##### Send a a weekly Digest
 
 For Heroku Scheduler users, there is a task that can be executed multiple times,
 but will only deliver mail on the environment's `DIGEST_DAY`.
@@ -109,10 +97,24 @@ rake digests:send_if_digest_day
 
 [![Heroku Scheduler](https://cloud.githubusercontent.com/assets/81055/8840908/732942c2-30b5-11e5-8af7-06b9e169d281.png)](https://devcenter.heroku.com/articles/scheduler)
 
-### Testing
 
-Run all tests in the `spec/` directory.
+### Developing
 
+As a developer you may want to:
+
+##### Set up a Single City Installation
+
+If you only need to support a single city you can specify the <kbd>ROOT_CITY_TAG</kbd> to bypass the index and load one city.
+
+For example, https://www.citygram.nyc/ is a single city installation with the following environment variable
+
+```
+ROOT_CITY_TAG=new-york
+```
+
+##### Test the code
+
+Run all tests in the `spec/` directory, by running:
 ```
 rake
 ```

--- a/README.md
+++ b/README.md
@@ -32,14 +32,18 @@ Citygram is a web application written in Ruby.
 
 ### Setup
 
-* Install Redis - `brew install redis`
+### Installation
+
+First, follow the instructions to install each of the following:
+
+* [Install Ruby](https://github.com/codeforamerica/howto/blob/master/Ruby.md) and [rbenv](https://github.com/sstephenson/rbenv#installation)
 * [Install PostgreSQL](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md)
 * Install PostGIS -- refer to [these troubles](https://github.com/codeforamerica/citygram/issues/188) on Mac OS X
-* [Install Ruby](https://github.com/codeforamerica/howto/blob/master/Ruby.md) ([rbenv guide](https://github.com/sstephenson/rbenv#installation))
-
-In the command line, run the following:
+* Install Redis - `brew install redis`
 
 #### Install Dependencies
+
+In the command line, run the following:
 
 ```
 git clone https://github.com/codeforamerica/citygram.git
@@ -51,7 +55,12 @@ rbenv rehash
 bundle install
 ```
 
+This will copy the code locally, then install all Ruby package dependencies.
+
+
 #### Configure Environment
+
+Make sure your PostgreSQL server is running, then in the terminal run:
 
 ```
 cp .env.sample .env
@@ -62,11 +71,15 @@ rake db:create db:migrate DATABASE_URL=postgres://localhost/citygram_test
 ### Developing
 
 To boot up the complete application and run background jobs in development:
-
 ```
 bundle exec foreman start
+```
+
+Then, in a new terminal window, run:
+```
 open http://localhost:5000/
 ```
+
 
 ##### Single City Installation
 


### PR DESCRIPTION
I'm a new user, and I found a few aspects of the documentation to be confusing. I've tried to address them here:

* There were two sections for installation / setup; one with individual items, the other with terminal commands. Some things also seem repeated there (e.g. postgresql and postgis install), while others were not explained.

* The "Developing" section didn't make sense to me--things like running the server commands aren't really developing. Instead, I created a "Running Citygram Services" section to separate those out.

One final question: is `brew install postgresql postgis` really necessary? The user was already requested to install those tools above. Would it be OK to delete that line?