### PR TITLE
Use turf to find event polygon surrounding a marker

### DIFF
--- a/app/assets/js/scripts.js
+++ b/app/assets/js/scripts.js
@@ -146,11 +146,9 @@ app.hookupSteps = function() {
       prevMarker = L.marker(latlng).addTo(app.map);
       prevCircle = L.circle(latlng, radiusMeters, { color:'#0B377F' }).addTo(app.map);
 
-
       if (app.eventsArePolygons) {
-        // copy title from the surrounding event polygon to the address marker
         app.updateEventsForGeometry(app.state.geom, function(events) {
-          prevMarker.bindPopup("<p>"+app.hyperlink(events[0]['title'])+"</p>").openPopup();
+          app.copyEventTitleToMarker(events, prevMarker);
         });
       }
 
@@ -178,6 +176,22 @@ app.hookupSteps = function() {
   $('#geolocateForm').on('submit', function(){ return false });
 
 };
+
+app.copyEventTitleToMarker = function(events, marker) {
+  var surroundingEvent;
+  var markerGeoJSON = marker.toGeoJSON();
+
+  events.forEach(function(event) {
+    var polygon = {"type": "Feature", geometry: JSON.parse(event.geom)};
+    if (turf.inside(markerGeoJSON, polygon)) {
+      surroundingEvent = event;
+    }
+  });
+
+  if (surroundingEvent) {
+    marker.bindPopup("<p>"+app.hyperlink(surroundingEvent.title)+"</p>").openPopup();
+  }
+}
 
 app.setPublisher = function($publisher) {
   app.state.publisher_id = $publisher.data('publisher-id');

--- a/app/views/show.erb
+++ b/app/views/show.erb
@@ -1,3 +1,5 @@
+<script src="//api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js"></script>
+
 <meta name="mapCenter" content="<%= @city.center.reverse.to_json %>">
 <style type="text/css">
   header { background: url(<%= asset_path "cities/backgrounds/#{@city.background}" %>); }


### PR DESCRIPTION
Fixes #215

This PR uses Turf.js to find the event that surrounds the marker.

I've tested with IE 10+ and no problems to report. That said, if anyone has any thoughts about other ways to determine the surrounding event, feel free to chime in.