### PR TITLE
Fix citygram.org: bad layout on iPhone #222.

### DIFF
--- a/app/assets/css/splash.scss.erb
+++ b/app/assets/css/splash.scss.erb
@@ -124,6 +124,10 @@ select {
   font-size: 1.3em;
 }
 
+#select-city {
+  max-width: 100%;
+}
+
 #contact {
   background-color: #59B390;
   color: white;


### PR DESCRIPTION
Fix for the city selector box not rendering correct for iPhone. This fix should also play nice with browser resizing and other small screen browsers, not limited to iPhone. Hopefully, this will assist with the user experience and increase citizen engagement.

Reference #222