### PR TITLE
ENH: click publisher button *anywhere*, not just on "choose"

### DIFF
--- a/app/assets/js/scripts.js
+++ b/app/assets/js/scripts.js
@@ -83,10 +83,10 @@ app.hookupSteps = function() {
     $('.publisher').removeClass('is-active');
   });
 
-  $('.publisher:not(.soon) .publisher-btn').on('click', function(event) {
+  $('.publisher:not(.soon)').on('click', function(event) {
     $('.publisher').removeClass('selected');
 
-    var $publisher = $(this).parents('.publisher:not(.soon)');
+    var $publisher = $(this);
     $publisher.addClass('selected');
 
     app.setPublisher($publisher);
@@ -102,6 +102,7 @@ app.hookupSteps = function() {
 
     app.scrollToElement($('#step2'));
   });
+
 
   app.handleChannelClick = function(channel, channelBtn) {
     if (channelBtn.hasClass('disabledButton')) {
@@ -200,7 +201,7 @@ app.hookupSteps = function() {
       // Preserve references to new layers
       prevMarker = L.marker(latlng).addTo(app.map);
       prevCircle = L.circle(latlng, radiusMeters, { color:'#0B377F' }).addTo(app.map);
-      
+
 
       if (app.eventsArePolygons) {
         app.updateEventsForGeometry(app.state.geom, function(events) {


### PR DESCRIPTION
The entire publisher `div` changes on hover, but in actuality one must click just the small "choose" button to actually select it. This is especially odd because the `div` *looks* like a button! This bit me in the ass all day today.

Made a small change to make the entire publisher area clickable.
![image](https://cloud.githubusercontent.com/assets/4072455/12046858/1ea91ca6-ae76-11e5-89b8-442fd5a866b5.png)
