### PR TITLE
BF: catch errors displaying any one event, to iterate through others.

### DIFF
--- a/app/assets/js/scripts.js
+++ b/app/assets/js/scripts.js
@@ -319,8 +319,11 @@ app.displayEventMarker = function(event) {
   } else {
     marker = L.circleMarker([geometry.coordinates[1], geometry.coordinates[0]], { radius: 6, color: '#FC442A' })
   }
-  marker.addTo(app.map).bindPopup(html);
-
+  try {
+    marker.addTo(app.map).bindPopup(html);
+  } catch (e) {
+    console.log("Error loading event '", event.title.substr(0, 10), "'", e);
+  }
   app.eventMarkers.addLayer(marker);
   return marker;
 }


### PR DESCRIPTION
Partial fix for #242 . I believe the Charlotte datafeed must be changed, but at least the script should not error--when it does, it doesn't attempt to show any events. 

If one event is bad, it should catch the error and try to show the rest. This change allows just that.