### PR TITLE
ENH: parse and recombine event title.

### DIFF
--- a/app/assets/js/scripts.js
+++ b/app/assets/js/scripts.js
@@ -312,8 +312,21 @@ app.selectTinyRadius = function() {
 
 app.displayEventMarker = function(event) {
   var geometry = JSON.parse(event.geom);
+  var titleParts = event.title.split("<br/>");  // hack, knowing DB output.
+  var addrParts = titleParts[0].split("at:");
+  var linkParts = titleParts[2].split("at:");
+  var html = "<div class='citygram-popup'>";
+  html += "<p class='addr'><span class='addr-title'>" + addrParts[0] + "at:</span><br/>";
+  html += "<span class='addr-value'>" + addrParts[1] + "</span></p>";
+  html += "<p class='title'>" + titleParts[1] + "<br/>";
+  html += "<a class='event-link' href='" + linkParts[1] + "'>More info</a></p>";
+  if (event.created_at) {
+    var dateString = (new Date(event.created_at)).toLocaleString('en').split(",")[0];
+    html += "<p class='date'>Posted on " + dateString + "</p>";
+  }
+  html += "</div>";
   var marker;
-  var html = "<p>"+app.hyperlink(event.title)+"</p>"
+
   if (app.eventsArePolygons) {
     marker = L.geoJson({"type": "Feature", "geometry": geometry});
   } else {


### PR DESCRIPTION
Workaround for #244 , fix for #97.

The HTML generated by the database and sent to the front-end is ... ugly and unstyleable (no div/span defined). In lieu of #244, I hackishly parse the HTML blob on the front-end, then style it up (barely). See before and after, below.

Along the way, I added "date posted" info.

Before:
![image](https://cloud.githubusercontent.com/assets/4072455/12047811/9f15e260-ae86-11e5-9a53-aa2eb08db6ce.png)


After:
![image](https://cloud.githubusercontent.com/assets/4072455/12047804/8cbf8fe4-ae86-11e5-9560-85f460613f2f.png)

