### PR TITLE
Update size of Leaflet map on mobile

### DIFF
--- a/app/assets/js/scripts.js
+++ b/app/assets/js/scripts.js
@@ -272,6 +272,9 @@ app.hyperlink = Autolinker.link;
 
 // Populate events
 app.updateEvents = function(bounds) {
+  // Update Leaflet map size on mobile
+  app.map.invalidateSize();
+
   var mapGeometry = {
     type: 'Polygon',
     coordinates: [[


### PR DESCRIPTION
When viewing the Leaflet map on mobile, the size does not dynamically change after a user selects a topic on the city page.

This fix checks to see if the size of the container has changed and updates the map accordingly.