### PR TITLE
Revising installation docs for greater clarity and ease of vagrant in…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp
 log
 .bundle
 dump.rdb
+.vagrant

--- a/README.md
+++ b/README.md
@@ -34,9 +34,16 @@ Citygram is a web application written in Ruby.
 
 ### Installation
 
-You can use [vagrant](http://vagrantup.com) to get up and running quickly:
+#### Option 1:
+For an OSX setup, you can use [vagrant](http://vagrantup.com) to get up and running quickly with [virtual box](http://virtualbox.org) and [homebrew](http:/brew.sh). This option will provide you with a smooth straight forward way of quickly getting you up and running.
 
 ```bash
+# setup homebrew
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+# setup virtualbox
+brew cask install virtualbox
+
 # starts up an ubuntu box and installs postgres and all other dependencies
 vagrant up
 
@@ -46,10 +53,11 @@ cd /vagrant
 bundle exec foreman start
 ```
 
+#### Option 2:
 First, follow the instructions to install each of the following:
 
 * [Install Ruby](https://github.com/codeforamerica/howto/blob/master/Ruby.md)
-* [Install PostgreSQL and PostGIS](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md) 
+* [Install PostgreSQL and PostGIS](https://github.com/codeforamerica/howto/blob/master/PostgreSQL.md)
 * Install Redis - `brew install redis` on OS X, available from your package manager on Linux or [direct download](http://redis.io/download)
 
 Then, in the command line, run the following to copy the citygram code locally and install all Ruby package dependencies:


### PR DESCRIPTION
…stall.

This would help to create greater clarity over the installation process with two options. There is added details regarding the vagrant installation process by adding homebrew and virtualbox dependencies. Ignoring the machine specific vagrant folder structure.