### PR TITLE
Brush off Vagrantfile

### DIFF
--- a/Procfile.vagrant
+++ b/Procfile.vagrant
@@ -1,2 +1,0 @@
-web: bundle exec rackup
-worker: bundle exec sidekiq -r ./app.rb


### PR DESCRIPTION
* Name Virtualbox VM to make it easier to find
* Prefer long form of flags for readibility
* Install git (needed by Gemfile dependency)
* Use .ruby-version to determine the version of Ruby to install to have
  less places to update if this changes
* Disable redis-server so it doesn't start on boot (in case the machine
  is rebooted).
* Remove Profile.vagrant (basic Procfile works fine and is the one
  referenced in the README)