### PR TITLE
[do not merge] Proof-of-concept for "themes"

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -23,7 +23,7 @@ module Citygram
       set :root, File.expand_path('../', __FILE__)
       set :logger, Logger.new(test? ? nil : STDOUT)
       set :map_id, ENV.fetch('MAP_ID') { 'codeforamerica.inb9loae' }
-      set :views, 'app/views'
+      set :views, ENV.fetch('VIEWS_DIR') { 'app/views' }
       set :erb, escape_html: true,
                 layout_options: { views: 'app/views/layouts' }
     end

--- a/app/views/experimental/_digest_events.erb
+++ b/app/views/experimental/_digest_events.erb
@@ -1,0 +1,15 @@
+<div class="table-responsive">
+  <table class="table table-hover">
+    <colgroup span="2" class="columns"></colgroup>
+    <tr>
+      <th class="col-sm-3"><h5>DATE</h5></th>
+      <th class="col-sm-9"><h5>CITYGRAM</h5></th>
+    </tr>
+    <% @events.each do |event| %>
+      <tr>
+        <td><%= event.created_at.strftime('%d %b %Y at %I:%m%P') %></td>
+        <td><%= hyperlink(event.title) %></td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/app/views/experimental/digest.erb
+++ b/app/views/experimental/digest.erb
@@ -1,0 +1,24 @@
+<div class="container">
+  <a href='/'>
+    <img src="<%= asset_path 'icons/citygram-logo-color.png' %>" width="150" class="logo">
+  </a>
+  <h1>Latest <span class="topic"><%= @subscription.publisher.title %></span>
+    for <span class="phone"><%= @subscription.nominative %></span></h1>
+
+  <div class="subscription-box">
+    <div class="row">
+      <div class="col-sm-1">
+        <img src="<%= asset_path "publishers/icons/#{@subscription.publisher.icon}" %>" class="icon">
+      </div>
+      <div class="col-sm-11">
+        <h5>YOUR SUBSCRIPTION FOR THE LAST WEEK:</h5>
+        <% single = @events.count == 1 %>
+        <!-- <h3>There <%=  single ? 'was' : 'were' %> <span class="orange"><%= @events.count %> citygram<%= single ? '' : 's' %></span> for <span class="navy"><%= @subscription.publisher.title %></span> within <span class="green">2 miles</span> of <span class="red">125 9th Street, Seattle.</span></h3> -->
+        <h3>There <%=  single ? 'was' : 'were' %> <span class="orange"><%= @events.count %> citygram<%= single ? '' : 's' %></span> for <span class="green"><%= @subscription.publisher.title %></span> in the area you selected.</h3>
+         <a href = "/unsubscribe/<%= @subscription.id %>">One-click Unsubscribe</a>
+      </div>
+    </div>
+  </div>
+
+  <%= erb :_digest_events %>
+</div>

--- a/app/views/experimental/email.erb
+++ b/app/views/experimental/email.erb
@@ -1,0 +1,48 @@
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>Your Citygram Digest for the Week</title>
+  <style media="all" type="text/css"></style>
+  <style type="text/css"><%= Citygram::App.assets['application.css'].source %></style>
+</head>
+
+<body class="digest-email">
+  <table cellspacing="0" cellpadding="0" border="0" width="100%">
+    <tr>
+      <td bgcolor="#FFFFFF" align="center">
+        <table width="700px" cellspacing="0" cellpadding="0" class="emailContainer">
+          <tr>
+            <td>
+              <img src="<%= Citygram::Routes::Helpers.build_url(Citygram::App.application_url, "/assets/#{Citygram::App.assets['icons/citygram-logo-color.png'].digest_path}") %>" width="150" class="logo">
+              <h1>Latest <span class="topic"><%= subscription.publisher.title %></span>
+                for <span class="phone"><%= subscription.email_address || subscription.phone_number %></span></h1>
+
+              <% single = events.count == 1 %>
+              <h5>In the last week, there <%=  single ? 'was' : 'were' %> <span class="orange"><%= events.count %> citygram<%= single ? '' : 's' %></span> for <span class="green"><%= subscription.publisher.title %></span> in the area you selected.</h5>
+              <h5>Here they are below, or view them <a href="<%= Citygram::Routes::Helpers.build_url(Citygram::App.application_url, "/digests/#{subscription.id}/events") %>" class="red">in a browser</a>.</h5>
+                <a href="<%= Citygram::Routes::Helpers.build_url(Citygram::App.application_url, "/unsubscribe/#{subscription.id}") %>">One-click Unsubscribe</a>
+              <br><br>
+
+              <table style="width:100%; font-size:11pt" bgcolor="#F8F9F9">
+                <col width="20%">
+                <col width="80%">
+                <tr>
+                  <th style="border:3px solid white; padding:10px; line-height:150%;"><h5>DATE</h5></th>
+                  <th style="border:3px solid white; padding:10px; line-height:150%;"><h5>CITYGRAM</h5></th>
+                </tr>
+              <% events.each do |event| %>
+                <tr>
+                  <td style="border:3px solid white; padding:10px; line-height:150%;"><%= event.created_at.strftime('%d %b %Y at %I:%m%P') %></td>
+                  <td style="border:3px solid white; padding:10px; line-height:150%;"><%= event.title %></td>
+                </tr>
+                <% end %>
+              </table>
+            </td>
+            <br><br>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/views/experimental/index.erb
+++ b/app/views/experimental/index.erb
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Citygram</title>
+
+  <!-- typekit -->
+  <script src="//use.typekit.net/fgr4sfu.js"></script>
+  <script>try{Typekit.load();}catch(e){}</script>
+
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+
+  <!-- the freshest styles -->
+  <link rel="stylesheet" type="text/css" href="<%= asset_path 'splash.css' %>">
+  <link rel="stylesheet" type="text/css" href="<%= asset_path 'footer.css' %>">
+
+</head>
+<body>
+<div class="jumbotron">
+  <div class="container">
+    <div class="row">
+      <div class="logo"></div>
+    </div>
+    <div>
+      <!--[if lt IE 10]>
+          <p class="alert alert-danger">You are using an older browser that is not currently supported. <a href="http://whatbrowser.org/">Upgrade your browser today</a> to fully use the site.</p>
+      <![endif]-->
+    </div>
+    <div class="row subscribe">
+      <h1 class="col-md-12">Subscribe to
+        <span class="dropdown">
+          <select id="select-city">
+            <option>your city</option>
+            <% @cities.each do |city| %>
+              <option value="/<%= city.id %>"><%= city.title %></option>
+            <% end %>
+          </select>
+        </span>
+      </h1>
+    </div>
+    <div class="row">
+      <h2 class="col-md-5">Get updates on the topics and areas you care about.</h2>
+    </div>
+  </div>
+</div>
+
+<section id="intro">
+  <div class="container">
+    <div class="row">
+      <span class="intro-q">Curious about the construction on your street?</span>
+      <span class="intro-q">How about the new restaurant going in down the block?</span>
+      <span class="intro-q">Want to know when there's a code violation in your area?</span>
+    </div>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="row">
+          <div class="col-md-12">
+            <h3><div class="parachute"></div> Introducing Citygram</h3>
+          </div>
+          <div class="col-md-12">
+            <p>Citygram is a notifications platform for subscribing to your city, whether it's foreclosures in your area or building permits along your commute. Sign up to find out about the things that matter to you where they matter to you.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+         <div class="row">
+          <div class="col-md-12">
+            <h3><div class="gears"></div> How it works</h3>
+          </div>
+          <div class="col-md-12">
+            <p>Citygram is a web application that can be hooked up to your city's open data platform. To create the notifications, the application regularly checks for new data and transforms it into human speak according to a template you define.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="contact">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-2 text-bubble">
+      </div>
+      <div class="col-md-9 contact-form">
+        <form action="https://docs.google.com/a/codeforamerica.org/forms/d/1JB1rrofsW3H310KSbmWXRiLjUbVKU06dUiGvratQRfw/formResponse" method="POST" id="ss-form" target="_self" onsubmit=""><ol role="list" class="ss-question-list" style="padding-left: 0">
+          <p>I want Citygram in <span class="city">
+            <input name="entry.2092787615" placeholder="MY CITY" type="text"></span> . My name is <span class="name">
+            <input name="entry.310801395" placeholder="FULL NAME" type="text"></span> and my email is <span class="email">
+             <input name="entry.1324690126" placeholder="YOU@EMAIL" type="text"></span>. Some topics I'd want: <span class="ideas">
+             <input name="entry.311709427" placeholder="ANY IDEAS HERE" type="text"></span>.</p>
+          <div class="submit-btn" onclick="$('#ss-form').submit()">Submit</div>
+        </form>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%= erb :'layouts/footer' %>
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+
+<!-- take me to my city! -->
+<script>
+
+var app = {};
+app.scrollToElement = function(el) {
+  $('html,body').animate({
+    scrollTop: el.offset().top
+  }, 800);
+};
+
+$("#select-city").change(function(e) {
+  var value = $(e.target).val();
+  if (value === "your-city") {
+    app.scrollToElement($("#ss-form"));
+  } else {
+    window.location.href = value;
+  }
+});
+</script>
+<%= erb :'layouts/analytics' %>
+</body>
+</html>

--- a/app/views/experimental/layouts/analytics.erb
+++ b/app/views/experimental/layouts/analytics.erb
@@ -1,0 +1,8 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-53540029-1', 'auto');
+  ga('send', 'pageview');
+</script>

--- a/app/views/experimental/layouts/footer.erb
+++ b/app/views/experimental/layouts/footer.erb
@@ -1,0 +1,28 @@
+<footer>
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12 col-md-2"><p>a project of</p></div>
+      <div class="col-xs-12 col-md-9">
+        <a href="http://www.codeforamerica.org/"><img src="<%= asset_path 'footer/cfa-icon.png' %>"></a>
+        <img src="<%= asset_path 'footer/plus-icon.png' %>">
+        <a href="http://charmeck.org/Pages/default.aspx"><img src="<%= asset_path 'footer/charlotte-icon.png' %>"></a>
+        <img src="<%= asset_path 'footer/plus-icon.png' %>">
+        <a href="http://www.lexingtonky.gov/"><img src="<%= asset_path 'footer/lexington-icon.png' %>"></a>
+        <img src="<%= asset_path 'footer/plus-icon.png' %>">
+        <a href="http://beta.nyc"><img src="<%= asset_path 'footer/betanyc-icon.png' %>"></a>
+      </div>
+      <div class="col-xs-0 col-md-1 text-right hidden-xs hidden-sm">
+        <a href="https://github.com/codeforamerica/citygram"><img src="<%= asset_path 'footer/github-icon.png' %>"></a>
+      </div>
+      <div class="col-xs-12 col-md-0 visible-xs visible-sm hidden-md">
+        <a href="https://github.com/codeforamerica/citygram"><img src="<%= asset_path 'footer/github-icon.png' %>"></a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<div class="award">
+  <div class="col-xs-12 col-md-9">
+    <a href="http://awards.codeforamerica.org/2015/winner/Citygram/"><img src="<%= asset_path 'footer/cfa-award-logo-purple-2.png' %>"></a>
+  </div>
+</div>    

--- a/app/views/experimental/layouts/layout.erb
+++ b/app/views/experimental/layouts/layout.erb
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="mapId" content="<%= Citygram::App.map_id %>">
+  <title>Citygram<%= " - #{@city.title}" if @city %></title>
+
+  <link rel="icon" type="image/png" href="<%= asset_path 'splash/parachute-indigo.png' %>">
+  <!--[if IE]><link rel="shortcut icon" href="<%= asset_path 'splash/parachute-indigo.png' %>" type="image/vnd.microsoft.icon" /><![endif]-->
+
+  <!-- typekit -->
+  <script type="text/javascript" src="//use.typekit.net/olg1fvr.js"></script>
+  <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+
+  <link rel="stylesheet" href="//api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.css" />
+
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+
+  <!-- the freshest styles -->
+  <link rel="stylesheet" type="text/css" href="<%= asset_path 'application.css' %>">
+  <link rel="stylesheet" type="text/css" href="<%= asset_path 'footer.css' %>">
+</head>
+<body>
+  <%= yield %>
+
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+
+  <script src="//api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.js"></script>
+
+  <!-- Latest compiled and minified JavaScript -->
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+
+  <!-- the highest quality javascripts -->
+  <script type="text/javascript" src="<%= asset_path 'application.js' %>"></script>
+  <%= erb :'layouts/analytics' %>
+
+  <script>
+    $("#title").fitText(1, { minFontSize: '40px', maxFontSize: '76px' });
+    $(".fit-h2").fitText(1, { minFontSize: '24px', maxFontSize: '40px' });
+    $(".fit-h3").fitText(1, { minFontSize: '16px', maxFontSize: '26px' });
+  </script>
+</body>
+</html>

--- a/app/views/experimental/reminder.erb
+++ b/app/views/experimental/reminder.erb
@@ -1,0 +1,27 @@
+<div class="container">
+  <a href='/'>
+    <img src="<%= asset_path 'icons/citygram-logo-color.png' %>" width="150" class="logo">
+  </a>
+  <h1><span class="topic"><%= @subscription.publisher.title %></span>
+    for <span class="phone"><%= @subscription.nominative %></span></h1>
+
+  <div class="subscription-box">
+    <div class="row">
+      <div class="col-sm-1">
+        <img src="<%= asset_path "publishers/icons/#{@subscription.publisher.icon}" %>" class="icon">
+      </div>
+      <div class="col-sm-11">
+        <h5>YOUR SUBSCRIPTION SINCE <%= @start_date.strftime("%b %d, %Y").upcase %>:</h5>
+        <% single = @event_count == 1 %>
+        <!-- <h3>There <%=  single ? 'was' : 'were' %> <span class="orange"><%= @events.count %> citygram<%= single ? '' : 's' %></span> for <span class="navy"><%= @subscription.publisher.title %></span> within <span class="green">2 miles</span> of <span class="red">125 9th Street, Seattle.</span></h3> -->
+        <h3>There <%=  single ? 'was' : 'were' %> <span class="orange"><%= @event_count %> citygram<%= single ? '' : 's' %></span> for <span class="green"><%= @subscription.publisher.title %></span> in the area you selected.</h3>
+        <% if @event_count > @events.count %>
+        <p>(We're showing you <%= @events.count %> of them.)</p>
+        <% end %>
+         <a href = "/unsubscribe/<%= @subscription.id %>">One-click Unsubscribe</a>
+      </div>
+    </div>
+  </div>
+
+  <%= erb :_digest_events %>
+</div>

--- a/app/views/experimental/show.erb
+++ b/app/views/experimental/show.erb
@@ -1,0 +1,169 @@
+<script src="//api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js"></script>
+
+<meta name="mapCenter" content="<%= @city.center.reverse.to_json %>">
+<style type="text/css">
+  header { background: url(<%= asset_path "cities/backgrounds/#{@city.background}" %>); }
+</style>
+
+<header class="container-fluid">
+  <div class="row">
+    <a href="/">
+      <div class="col-xs-offset-1 col-md-offset-1 logo"></div>
+    </a>
+  </div>
+  <div class="row">
+    <h1 id="title" class="col-xs-offset-1 col-md-offset-1 col-md-10">Subscribe to <span class="no-wrap"><%= @city.title %></span>.</h1>
+  </div>
+  <div class="row">
+    <h3 class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-5">Get updates on the topics and areas you care about in <span class="no-wrap"><%= @city.title %></span>.</h3>
+    <div id="start" class="hidden-xs hidden-sm col-md-offset-3 bigButton startButton">Get started</div>
+  </div>
+</header>
+
+<section id="step1" class="container-fluid">
+  <div class="instruction row">
+    <div class="col-xs-offset-1 col-md-offset-1 col-md-11">
+      <h2 class="fit-h2">1. Select a topic.</h2>
+      <h3 class="fit-h3">Choose one to start, and you can add more later.</h3>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="publishers col-xs-offset-1 col-md-offset-1 col-md-11">
+      <!--[if lt IE 10]>
+          <p class="alert alert-danger">You are using an older browser that is not currently supported. <a href="http://whatbrowser.org/">Upgrade your browser today</a> to fully use the site.</p>
+      <![endif]-->
+      <% @publishers.each do |publisher| %>
+        <div class="publisher <%= 'soon' unless publisher.active %>"
+          data-publisher-event-display-endpoint="<%= publisher.event_display_endpoint %>"
+          data-publisher-events-are-polygons="<%= publisher.events_are_polygons %>"
+          data-publisher-id="<%= publisher.id %>"
+          data-publisher-title="<%= publisher.title %>"
+          data-publisher-city="<%= publisher.city %>"
+          data-publisher-state="<%= publisher.state %>">
+          <div class="publisher-topic">
+            <div class="title"><%= publisher.title %></div>
+            <img src="<%= asset_path "publishers/icons/#{publisher.icon}" %>">
+          </div>
+          <div class="publisher-description">
+            <div class="definition"><strong><%= publisher.title %>:</strong> <%= publisher.description %></div>
+            <br>
+            <button type="button" class="publisher-btn btn btn-info btn-lg">choose</button>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>
+
+<section id="step2" class="container-fluid">
+  <div class="instruction row">
+    <div class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-10">
+      <h2 class="fit-h2">2. What's your address?</h2>
+      <h3 class="fit-h3">Your home, your work, or wherever's important to you.</h3>
+    </div>
+  </div>
+
+  <div class="row">
+    <form id="geolocateForm" role="form">
+        <div class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-5">
+          <input type="text" id="geolocate" placeholder="Your address"></input>
+        </div>
+
+        <div class="col-xs-offset-1 col-md-offset-0 col-xs-10 col-md-5">
+          <span class="bigSelect">
+            <select id="user-selected-radius">
+              <option value="0.1">Within a 1/10 mile (about a stone's throw)</option>
+              <option value="0.25">Within a 1/4 mile (about a 5 min leisurely stroll)</option>
+              <option value="0.5">Within a 1/2 mile (about an 8 min power walk)</option>
+              <option value="1">Within 1 mile (about 15 min on horse and buggy)</option>
+              <option value="2">Within 2 miles (about a 7 min bicycle jaunt)</option>
+              <option value="3">Within 3 miles (about an 8 min vespa ride)</option>
+              <option value="4">Within 4 miles (about a 2 day bear crawl)</option>
+              <span class="caret"></span>
+            </select>
+          </span>
+        </div>
+    </form>
+  </div>
+
+  <div class="row">
+    <div class="col-md-offset-1 col-md-10">
+      <div id="locatormap"></div>
+      <% if !@city.sub_cities.nil? %>
+        <div id="user-selected-locality" class="menu-ui">
+          <% @city.sub_cities.each do |sub_city| %>
+            <a href="#" data-position="<%= sub_city['geometry']['coordinates'].reverse.join(",") %>" data-city="<%= sub_city['properties']['title'] %>" data-state="<%= sub_city['properties']['state'] %>"><%= sub_city['properties']['title'] %></a>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div class="frequencyContainer">
+        <img src="<%= asset_path 'icons/frequency.png' %>" class="frequencyIcon">
+        <div class="frequencyText">
+          <span class="frequencyTitle">Estimated Frequency</span>
+          <p>
+            In the last week, there were about <span id="freqNum" class="orange bold">___ citygrams</span> for <span class="confirmationType navy bold">___</span> within <span id="freqRadius" class="green bold">___ mi</span> of <span id="freqAddress" class="red bold">___</span>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</section>
+
+<section id="step3" class="container-fluid">
+  <div class="instruction row">
+    <div class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-10">
+      <h2 class="fit-h2">3. How do you want to be notified?</h2>
+      <h3 class="fit-h3">Get text messages as each event is posted, or get a weekly email digest.</h3>
+    </div>
+  </div>
+
+  <div class="channelButtons row">
+    <div class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-5">
+      <div class="bigButton orangeButton smsButton disabledButton"><span>text</span></div>
+    </div>
+    <div class="col-xs-offset-1 col-xs-10 col-md-offset-0 col-md-5">
+      <div class="bigButton greenButton emailButton disabledButton"><span>email</span></div>
+    </div>
+  </div>
+
+  <div class="disabledInfo row" style="display:none">
+    <div class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-10">
+      <h2 class="orange">Oops! Select a topic and an area first.</h2>
+    </div>
+  </div>
+
+  <div class="extraInfo row" style="display:none">
+    <form id="subscribeForm">
+      <div class="col-xs-offset-1 col-xs-10 col-md-7 channel-inputs">
+        <input type="text" style="display:none" class="js-channel-sms phoneNumber" placeholder="phone number">
+        <input type="email" style="display:none" class="js-channel-email emailAddress" placeholder="email">
+      </div>
+      <input type="submit" style="display:none"/>
+    </form>
+    <div class="col-xs-offset-1 col-xs-10 col-md-offset-0 col-md-3">
+      <div class="bigButton orangeButton subscribeButton">subscribe</div>
+    </div>
+  <div>
+</section>
+
+<section id="confirmation" class="container-fluid" style="display:none">
+  <div class="row">
+    <div class="col-xs-offset-1 col-xs-10 col-md-offset-1 col-md-10">
+      <div class="js-confirm-channel js-confirm-sms" style="display:none">
+        <p>You're subscribed to <strong class="confirmationType">traffic incidents</strong> in your area!</p>
+        <p>Look out for your confirmation text shortly.</p>
+      </div>
+      <div class="js-confirm-channel js-confirm-email" style="display:none">
+        <p>You're subscribed to <strong class="confirmationType">traffic incidents</strong> in your area!</p>
+        <p>Look out for the Citygram email digest on <strong><%= Date.parse(ENV.fetch('DIGEST_DAY')).strftime('%A') + 's' %>.</strong></p>
+      </div>
+      <div class="bigButton greenButton resetButton">sign up for another topic</div>
+      <a href="" id="view-subscription" class="bigButton greenButton resetButton">view your subscription</a>
+    </div>
+  </div>
+</section>
+
+<%= erb :'layouts/footer' %>

--- a/app/views/experimental/unsubscribe.erb
+++ b/app/views/experimental/unsubscribe.erb
@@ -1,0 +1,4 @@
+<div class="container">
+  <img src="<%= asset_path 'icons/citygram-logo-color.png' %>" width="150" class="logo">
+  <h1>Successfully unsubscribed <span class="topic"><%= @subscription.email_address %></span> from <span class="topic"><%= @subscription.publisher.title %></span></h1>
+</div>


### PR DESCRIPTION
This is meant to be an proof-of-concept for discussion.

We, the San Francisco Digital Services Team, desire to experiment with modifying the Citygram user interface to satisfy the user needs we've identified in by talking with City employees as well as residents. We want to do this in a way that allows us to keep our fork in sync with the Citygram upstream so that we can more easily contribute mutually beneficial changes back and to pull relevant updates down.

This PR is meant to represent a proof-of-concept of one approach we could take to this, namely, to create a new directory in `app/views` that we could iterate on this interface within. This would allow us to issue PRs upstream that could safely be merged without affecting existing cities using Citygram.

A goal, once this new interface is stabilized, would be to open it up as an option for other cities to opt into. To support this, we will keep the "theme" as agnostic as possible, injecting City specific configuration.

I'm also interested in suggestions of alternative approaches that could satisfy this desire to stay as close as we can to the canonical repository.

For context, we expect to run Citygram as a separate install from citygram.org to take ownership over the monitoring, analytics, costs, etc..