### PR TITLE
Update .travis.yml to handle forks and deploying to Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,11 @@ script:
   - bundle exec rake db:migrate DATABASE_URL=postgres://localhost/citygram_test
   - bundle exec rake
 after_success:
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
-    docker push citygram/data;
-    docker push citygram/citygram;
+  - if [[ "$TRAVIS_REPO_SLUG" == 'codeforamerica/citygram' && "$TRAVIS_BRANCH" == "master" ]] ; then
+      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      docker push citygram/data;
+      docker push citygram/citygram;
     fi
-
 notifications:
   webhooks: http://project-monitor.codeforamerica.org/projects/77db7e4d-a05a-4ee8-b7ab-3bd29c6dd1b0/status
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,15 @@ after_success:
     fi
 notifications:
   webhooks: http://project-monitor.codeforamerica.org/projects/77db7e4d-a05a-4ee8-b7ab-3bd29c6dd1b0/status
+deploy:
+  provider: heroku
+  api_key:
+    "$HEROKU_API_KEY"
+  app: "$HEROKU_APP"
+  on:
+    branch: master
+    condition: "$HEROKU_API_KEY != '' && $HEROKU_APP != ''"
+    ruby: '2.5.0'
 dist: trusty
 sudo: required
 cache: bundler


### PR DESCRIPTION
Update .travis.yml to only push to Dockerhub on the canonical repository and to deploy to Heroku in a fork friendly way.

Allows us to test and deploy our fork separately.

Open to other approaches! Running forks on TravisCI doesn't seem to be a normal use-case so is a bit awkward to manage, but I don't think we'll need much more than this for our purposes.

https://github.com/travis-ci/travis-ci/issues/1094 is an example of them considering moving notifications to the web interface to better support forks (among other reasons).