### PR TITLE
Move image building and pushing to seperate job in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
         on:
           branch: master
     - stage: deploy
+      if: "branch = master AND env(HEROKU_API_KEY) IS present AND env(HEROKU_APP) is present"
       before_install: skip
       install: skip
       script: skip
@@ -55,6 +56,3 @@ jobs:
         api_key:
           "$HEROKU_API_KEY"
         app: "$HEROKU_APP"
-        on:
-          branch: master
-          condition: "$HEROKU_API_KEY != '' && $HEROKU_APP != ''"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+sudo: false
 language: ruby
 rvm:
   - 2.5.0
   - ruby-head
 services:
   - postgresql
-  - docker
 addons:
   postgresql: 9.6
   apt:
@@ -14,37 +14,47 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 before_install:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y install docker-ce
   - psql -c 'create database citygram_test;' -U postgres
   - psql -U postgres -c "create extension postgis"
-  - docker build -f docker/data/Dockerfile -t citygram/data .
-  - docker build -f docker/citygram/Dockerfile -t citygram/citygram .
   - gem update --system
   - gem install bundler
 script:
   - cp .env.sample .env
   - bundle exec rake db:migrate DATABASE_URL=postgres://localhost/citygram_test
   - bundle exec rake
-after_success:
-  - if [[ "$TRAVIS_REPO_SLUG" == 'codeforamerica/citygram' && "$TRAVIS_BRANCH" == "master" ]] ; then
-      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-      docker push citygram/data;
-      docker push citygram/citygram;
-    fi
 notifications:
   webhooks: http://project-monitor.codeforamerica.org/projects/77db7e4d-a05a-4ee8-b7ab-3bd29c6dd1b0/status
-deploy:
-  provider: heroku
-  api_key:
-    "$HEROKU_API_KEY"
-  app: "$HEROKU_APP"
-  on:
-    branch: master
-    condition: "$HEROKU_API_KEY != '' && $HEROKU_APP != ''"
-    ruby: '2.5.0'
-dist: trusty
-sudo: required
 cache: bundler
+
+jobs:
+  include:
+    - stage: images
+      services:
+        - docker
+      dist: trusty
+      sudo: required
+      before_install: skip
+      install: skip
+      script:
+        - docker build -f docker/data/Dockerfile -t citygram/data .
+        - docker build -f docker/citygram/Dockerfile -t citygram/citygram .
+      deploy: # needs to be part of this step to have access to the built images
+        provider: script
+        script:
+          - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          - docker push citygram/data
+          - docker push citygram/citygram
+        on:
+          branch: master
+    - stage: deploy
+      before_install: skip
+      install: skip
+      script: skip
+      deploy:
+        provider: heroku
+        api_key:
+          "$HEROKU_API_KEY"
+        app: "$HEROKU_APP"
+        on:
+          branch: master
+          condition: "$HEROKU_API_KEY != '' && $HEROKU_APP != ''"


### PR DESCRIPTION
This was a small rabbit hole I dove into.

Making use of [TravisCI Build Stages](https://docs.travis-ci.com/user/build-stages/)

This has the advantages of:

* Allowing the Ruby tests to run on the default TravisCI container infrastructure (much faster: 2 minutes vs. 4 minutes for this step).
* Only spend time building the image if the tests pass
* Logically separating the two "tasks" which, I think, makes it easier to follow

Additionally I remove installing `docker-ce` since it doesn't appear to be needed at this point (I couldn't tell which version was desired by https://github.com/BetaNYC/citygram-nyc/pull/108/commits/060dccf42285caf848fb99d300bca39e42424665).

Example build: https://travis-ci.org/SFDigitalServices/citygram

The image build step still takes ~4 additional minutes, but I think the ability to get more rapid feedback from failed builds if the tests fail is useful. I think I can speed up the image build step by caching the Docker layers, but I'll leave that for a future PR.

I'll need to update either this or #275 if one is merged.