### PR TITLE
Update Sinatra to 1.4.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     phone (1.3.0.beta1)
     pony (1.11)
       mail (>= 2.0)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-mount (0.8.3)
@@ -129,8 +129,8 @@ GEM
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
       redis-namespace (~> 1.5, >= 1.5.2)
-    sinatra (1.4.6)
-      rack (~> 1.4)
+    sinatra (1.4.8)
+      rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     sprockets (2.12.4)
@@ -202,4 +202,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Cleans up warnings about ::Fixnum deprecation for newer Ruby versions and keeps
us more current.

[Sinatra CHANGELOG](https://github.com/sinatra/sinatra/blob/master/CHANGELOG.md)

The newest Sinatra is actually 2.0.3, but this would be a major version bump
and thus probably more risky (though I didn't immediately see anything in the
CHANGELOG that would indicate significant compatibility breaks).

Would you be interested in me looking into what it would take take update to
the latest?

Also, I've used [dependabot](https://dependabot.com/) on other projects to help
keep there dependencies up-to-date (it automatically opens PRs with
Gemfile.lock updates; [example
PR](https://github.com/sfbrigade/adopt-a-drain/pull/329)). Is this something
you might be interested in integrating here? It introduces more maintenance
work, but I find it's easier to take that work on (smaller incremental updates
on a regular basis) than have to do "big bang" upgrades more infrequently. Up
to you.

Thanks!