### PR TITLE
Add CORS to allow requests from non-same origins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'json', github: 'flori/json', branch: 'v1.8' # https://github.com/flori/json
 gem 'pg'
 gem 'phone', '~> 1.3.0.beta0'
 gem 'pony', '~> 1.9'
+gem 'rack-cors', :require => 'rack/cors'
 gem 'rack-ssl'
 gem 'rake'
 gem 'sass', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     rack (1.6.9)
     rack-accept (0.4.5)
       rack (>= 0.4)
+    rack-cors (1.0.2)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
     rack-protection (1.5.5)
@@ -184,6 +185,7 @@ DEPENDENCIES
   pg
   phone (~> 1.3.0.beta0)
   pony (~> 1.9)
+  rack-cors
   rack-ssl
   rack-test
   rake
@@ -202,4 +204,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/config.ru
+++ b/config.ru
@@ -1,9 +1,12 @@
 require './app'
 
-use Rack::Cors do
-  allow do
-    origins '*'
-    resource '*', headers: ['Content-Type'], methods: :get
+# Allow external querying of Citygram data from another origin
+if allowed_origins = ENV.fetch('CORS_ALLOWED_ORIGINS', false)
+  use Rack::Cors do
+    allow do
+      origins allowed_origins
+      resource '*', headers: ['Content-Type'], methods: :get
+    end
   end
 end
 

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,12 @@
 require './app'
 
+use Rack::Cors do
+  allow do
+    origins '*'
+    resource '*', headers: ['Content-Type'], methods: :get
+  end
+end
+
 unprotected_routes = [
   Citygram::Routes::Events,
   Citygram::Routes::Publishers,

--- a/spec/rack_config_spec.rb
+++ b/spec/rack_config_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'config.ru' do
+  include Rack::Test::Methods
+
+  def app
+    ENV['CORS_ALLOWED_ORIGINS'] = 'http://example.com'
+    Rack::Builder.parse_file(File.expand_path('../../config.ru', __FILE__)).first
+  end
+
+  context 'when $CORS_ALLOWED_ORIGINS is set' do
+    context 'when disallowed origin is specified' do
+      it 'does not set CORS headers if bad origin' do
+        header 'Origin', 'http://foobar.com'
+        options '/publishers'
+        expect(last_response.headers).to_not include('Access-Control-Allow-Origin')
+      end
+    end
+
+    context 'when allowed origin is specified' do
+      it 'sets CORS headers' do
+        header 'Origin', 'http://example.com'
+        header 'Access-Control-Request-Method', 'GET'
+        header 'Access-Control-Request-Headers', 'Content-Type'
+        options '/'
+
+        expect(last_response.headers['Access-Control-Allow-Origin']).to eq 'http://example.com'
+        expect(last_response.headers['Access-Control-Allow-Headers']).to eq 'Content-Type'
+        expect(last_response.headers['Access-Control-Allow-Methods']).to eq 'GET'
+      end
+    end
+  end
+end


### PR DESCRIPTION
The intention of this is to allow Citygram to be fronted by a separate web interface that is still able to access event and publisher information by API.

I'm not a CORS expert so I especially welcome opinions, but I believe exposing these `GET` routes in this manner to be OK.

See https://github.com/codeforamerica/citygram/pull/273#issuecomment-403101644 for more context of why I'd like to enable cross-origin requests.

References:
* https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
* https://www.owasp.org/index.php/CORS_OriginHeaderScrutiny