### PR TITLE
End endpoint for querying an individual event by id

### DIFF
--- a/app/routes/events.rb
+++ b/app/routes/events.rb
@@ -22,5 +22,9 @@ module Citygram::Routes
       geom = GeoRuby::GeojsonParser.new.parse(params[:geometry]).as_ewkt
       Event.from_geom(geom, params).limit(1000)
     end
+
+    get 'events/:event_id' do
+      Event.with_pk!(params[:event_id])
+    end
   end
 end

--- a/spec/routes/events_spec.rb
+++ b/spec/routes/events_spec.rb
@@ -13,4 +13,13 @@ describe Citygram::Routes::Events do
       expect(last_response.body).to eq events.reverse.to_json
     end
   end
+
+  describe 'GET events/:id' do
+    it 'returns events for a given description' do
+      event = create(:event)
+
+      get "/events/#{event.id}"
+      expect(JSON.parse(last_response.body)["id"]).to eq event.id
+    end
+  end
 end


### PR DESCRIPTION
Enable querying for an individual event id.

See https://github.com/codeforamerica/citygram/pull/273#issuecomment-403101644 for more context. To enable creation of a separate UI layer, we'd like to be able to load individual IDs by ID to show more information to the end-user.

Related: #279 