### PR TITLE
Allow querying for publishers by tag

### DIFF
--- a/app/routes/publishers.rb
+++ b/app/routes/publishers.rb
@@ -12,10 +12,13 @@ module Citygram::Routes
     params do
       optional :page, type: Integer, default: 1
       optional :per, type: Integer, default: 10, max: 1000
+      optional :tag, type: String
     end
 
     get '/publishers' do
-      Publisher.dataset.paginate(params[:page], params[:per]).order(Sequel.desc(:created_at))
+      Publisher.dataset.yield_self do |publishers|
+        params[:tag] ? publishers.tagged(params[:tag]) : publishers
+      end.paginate(params[:page], params[:per]).order(Sequel.desc(:created_at))
     end
 
     desc <<-DESC

--- a/spec/routes/publishers_spec.rb
+++ b/spec/routes/publishers_spec.rb
@@ -16,6 +16,13 @@ describe Citygram::Routes::Publishers do
       get '/publishers', params
       expect(last_response.body).to eq [publishers[2], publishers[1]].to_json
     end
+
+    it 'filters by tag' do
+      tagged_publisher = create(:publisher, tags: ['tagged', 'foobar'])
+      create(:publisher, tags: ['foobar'])
+      get '/publishers', { tag: 'tagged' }
+      expect(last_response.body).to eq [tagged_publisher].to_json
+    end
   end
 
   describe 'GET /publishers/:publisher_id/events_count' do


### PR DESCRIPTION
Allowing for external querying of publishers for a given city similar to the logic encoded in in Citygram::Routes::Page (https://github.com/codeforamerica/citygram/blob/master/app/routes/page.rb#L5).