### PR TITLE
Only create postgis extension if it isn't already enabled

### DIFF
--- a/db/migrations/001_enable_postgis_extension.rb
+++ b/db/migrations/001_enable_postgis_extension.rb
@@ -1,6 +1,6 @@
 Sequel.migration do
   up do
-    execute %{ CREATE EXTENSION "postgis"; }
+    execute %{ CREATE EXTENSION IF NOT EXISTS "postgis"; }
   end
 
   down do


### PR DESCRIPTION
When using the mdillon/postgis docker image (also used by docker/data/Dockerfile), the extension is already enabled.