### PR TITLE
Rely on application to run database migrations for docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,11 @@ jobs:
       before_install: skip
       install: skip
       script:
-        - docker build -f docker/data/Dockerfile -t citygram/data .
         - docker build -f docker/citygram/Dockerfile -t citygram/citygram .
       deploy: # needs to be part of this step to have access to the built images
         provider: script
         script:
           - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          - docker push citygram/data
           - docker push citygram/citygram
         on:
           branch: master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.1"
 
 services:
   db:
-    image: citygram/data
+    image: mdillon/postgis
     networks:
       - citygram
     ports:
@@ -13,6 +13,17 @@ services:
     networks:
       - citygram
     container_name: citygram_redis
+
+  citygram_migration:
+    image: citygram/citygram
+    networks:
+      - citygram
+    environment:
+      DATABASE_URL: postgres://postgres@citygram_db/citygram_development
+    command: bundle exec rake db:create db:migrate
+    depends_on:
+      - db
+
   citygram:
     image: citygram/citygram
     environment:
@@ -21,5 +32,9 @@ services:
       - "9292:9292"
     networks:
       - citygram
+    depends_on:
+      - db
+      - redis
+      - citygram_migration
 networks:
   citygram:

--- a/docker/data/Dockerfile
+++ b/docker/data/Dockerfile
@@ -1,4 +1,0 @@
-FROM mdillon/postgis
-
-COPY db/schema.sql /tmp/schema.sql
-COPY docker/data/schema.sh /docker-entrypoint-initdb.d/schema.sh

--- a/docker/data/schema.sh
+++ b/docker/data/schema.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-createdb -U postgres citygram_test
-createdb -U postgres citygram_development
-
-psql -U postgres citygram_test < /tmp/schema.sql
-psql -U postgres citygram_development < /tmp/schema.sql


### PR DESCRIPTION
Curious to get thoughts on this one!

I personally view it as a responsibility of the application to run database migrations. Rather than build a separate docker image that is the `mdillon/postgis` + the dumped schema from `rake db:migrate` and friends (imported in the entrypoint), we can instead use the image as-is and rely on docker-compose to run the migrations as part of `docker-compose up`.

Overall I think this reduces maintenance burden, but I'm open to other thoughts.

Depends on #284 