### PR TITLE
Allow the docker image tags to be overridden in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,14 @@ jobs:
       before_install: skip
       install: skip
       script:
-        - docker build -f docker/data/Dockerfile -t citygram/data .
-        - docker build -f docker/citygram/Dockerfile -t citygram/citygram .
+        - docker build -f docker/data/Dockerfile -t ${DOCKER_IMAGE_DATA-citygram/data} .
+        - docker build -f docker/citygram/Dockerfile -t ${DOCKER_IMAGE_CITYGRAM-citygram/citygram} .
       deploy: # needs to be part of this step to have access to the built images
         provider: script
         script:
           - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          - docker push citygram/data
-          - docker push citygram/citygram
+          - docker push ${DOCKER_IMAGE_DATA-citygram/data}
+          - docker push ${DOCKER_IMAGE_CITYGRAM-citygram/citygram}
         on:
           branch: master
     - stage: deploy


### PR DESCRIPTION
Will allow forks to more easily publish images.

To ease development of the separate Citygram front-end mentioned in https://github.com/codeforamerica/citygram/pull/273#issuecomment-403101644, it'd be useful to push separate images while our changes are integrated upstream.